### PR TITLE
Initial working JSON graph converter, I think.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+		  "type": "node",
+		  "request": "launch",
+		  "name": "Launch current file w/ ts-node",
+		  "protocol": "inspector",
+		  "args": ["${relativeFile}"],
+		  "cwd": "${workspaceRoot}",
+		  "runtimeArgs": ["-r", "ts-node/register"],
+		  "internalConsoleOptions": "openOnSessionStart"
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # grafiki
 Making JSON more graph like. Just like Rafiki helped Mufasa remember who he is, Grafiki helps JSON nodes remember who they are.
+
+# WHY?
+Mainly because I had a long weekend to work on a project. But secondly, because there was need to convert GunDB into typescript. But as I was working, I wanted to make some changes so I did.
+
+# WHAT DOES IT DO?
+It allows JSON to have circular references by storing ID of nodes, instead of the actual object. Using the Grafiki api of ref/put/push/getData/val to do what you want with the JSON.
+
+# WHAT's Next??
+I am hoping to end this project early and little by little add things to it. Currently I just want it to generate the circular JSON, and read it from a localStorage for persistent data. GunDB does all the fancy networking thing, maybe I will add that here or create a separate module for it. Time will tell.
+
+If it Helps you out... Enjoy!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,99 @@
+{
+  "name": "grafiki",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "dev": true
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+      "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "1.1.1",
+        "source-map": "0.6.1"
+      }
+    },
+    "ts-node": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+      "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "buffer-from": "1.1.1",
+        "diff": "3.5.0",
+        "make-error": "1.3.5",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.5.9",
+        "yn": "2.0.0"
+      }
+    },
+    "typescript": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.1.tgz",
+      "integrity": "sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg==",
+      "dev": true
+    },
+    "yn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "grafiki",
+  "version": "0.0.1",
+  "description": "Small API for making JSON circular references possible.",
+  "main": "src/Grafiki.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/to-jajav33/grafiki.git"
+  },
+  "keywords": [
+    "JSON",
+    "Circular",
+    "Reference",
+    "JSON"
+  ],
+  "author": "Jajav33",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/to-jajav33/grafiki/issues"
+  },
+  "homepage": "https://github.com/to-jajav33/grafiki#readme",
+  "devDependencies": {
+    "ts-node": "^7.0.1",
+    "typescript": "^3.2.1"
+  }
+}

--- a/src/Grafiki.ts
+++ b/src/Grafiki.ts
@@ -1,0 +1,75 @@
+
+import { GNodeRoot } from "./components/GNodeRoot";
+import * as MyWebSocket from 'ws';
+import { IGNodeOptions } from "./components/GNode";
+
+interface IGrafikiParams {
+	port ?: number,
+	nodeOptions : IGNodeOptions 
+}
+
+interface IGrafikiOptions {
+	port : number
+}
+
+
+export class Grafiki extends GNodeRoot {
+	private __wsServer : MyWebSocket.Server;
+	protected __grafikiOptions : IGrafikiOptions
+
+	constructor (paramOptions : IGrafikiParams = {nodeOptions : {root: undefined}}) {
+		paramOptions.nodeOptions.root = undefined;
+
+		super(paramOptions.nodeOptions);
+
+		this.__options.root = this;
+		this.__grafikiOptions = {
+			port: paramOptions.port
+		};
+
+		this.__init();
+	}
+
+	private __init () {
+		if (this.__wsServer) return;
+
+		let port : number = this.__grafikiOptions.port;
+
+		try {
+			if (port) {
+				this.__onConnection = this.__onConnection.bind(this);
+				this.__onMessage = this.__onMessage.bind(this);
+
+				this.__wsServer = new MyWebSocket.Server({port});
+	
+				this.__wsServer.on('connection', this.__onConnection);
+			}
+		} catch (e) {
+			return e;
+		}
+	}
+
+	/**
+	 * Listern for then server connectss.
+	 *
+	 * @private
+	 * @param {*} paramWs
+	 * @memberof Grafiki
+	 */
+	private __onConnection (paramWs) {
+		paramWs.on('message', this.__onMessage);
+	}
+
+	/**
+	 * Listener for when a message is received
+	 *
+	 * @private
+	 * @param {*} paramMessage
+	 * @memberof Grafiki
+	 */
+	private __onMessage (paramMessage) {
+		// console.log('received:', paramMessage);
+	}
+}
+
+

--- a/src/components/GNode.ts
+++ b/src/components/GNode.ts
@@ -1,0 +1,305 @@
+import { GNodeRoot } from "./GNodeRoot";
+import { GUID_NODES } from "./GUID_NODES";
+import { Utils } from "./Utils";
+
+/**
+ * Interface representing the data found in GNode
+ *
+ * @export
+ * @interface IGNodeData
+ */
+export interface IGNodeData {
+	branches: undefined | object,
+	nodeId: string,
+	value: boolean | null | number | string | undefined | GNode,
+	timestamp: number
+}
+
+/**
+ * Interface representing values passed in at constructor of GNode
+ *
+ * @export
+ * @interface IGNodeOptions
+ */
+export interface IGNodeOptions {
+	root: GNodeRoot
+}
+
+/**
+ * Interface representing parameter options passed in for GNode.getData();
+ *
+ * @interface IGetDataOptions
+ */
+interface IGetDataOptions {
+}
+
+/**
+ * Node in the graph system.
+ *
+ * @export
+ * @class GNode
+ */
+export class GNode {
+	protected __options: IGNodeOptions;
+	protected __path: Array<string>;
+	protected __parentNode: GNode;
+	protected __data: IGNodeData;
+
+	get data() {
+		return this.__data;
+	}
+
+	get nodeId() {
+		return this.__data.nodeId;
+	}
+
+	get parentNode() {
+		return this.__parentNode;
+	}
+
+	get path() {
+		return (Array.isArray(this.__path)) ? this.__path.concat() : null;
+	}
+
+	get root() {
+		return this.__options.root;
+	}
+
+	constructor(paramOptions: IGNodeOptions) {
+		this.__options = paramOptions;
+
+		// add defaults
+		this.__data = {
+			branches: {},
+			value: undefined,
+			timestamp: Date.now(),
+			nodeId: GUID_NODES.key()
+		};
+	}
+
+	/**
+	 * Creates a uid key and wraps the incoming data in it to create a list.
+	 *
+	 * @param {(Array<object|boolean|GNode|number|null|string>|object|boolean|GNode|number|null|string)} paramData
+	 * @returns {Promise<GNode>} returns itself.
+	 * @memberof GNode
+	 */
+	async push(paramData: Array<object | boolean | GNode | number | null | string> | object | boolean | GNode | number | null | string): Promise<GNode> {
+		let pushKey: string = GUID_NODES.key();
+		let newData: object = {};
+		newData[pushKey] = paramData;
+
+		return await this.put(newData)
+	}
+
+	/**
+	 * 
+	 *
+	 * @param {(Array<object|boolean|GNode|number|null|string>|object|boolean|GNode|number|null|string)} data
+	 * @returns {Promise<GNode>} Returns itself
+	 * @memberof GNode
+	 */
+	async put(paramData: Array<object | boolean | GNode | number | null | string> | object | boolean | GNode | number | null | string): Promise<GNode> {
+		try {
+			let objectArrayData;
+			if (paramData && (paramData instanceof GNode)) {
+				// passing in a gnode creates an object with a uid and a branch to connect the GNode
+				let nodeId = paramData.__data.nodeId;
+				objectArrayData = {};
+				objectArrayData[nodeId] = nodeId;
+			} else if (paramData && (typeof paramData === 'object') || (Array.isArray(paramData))) {
+				objectArrayData = paramData;
+			}
+
+			if (objectArrayData && (typeof objectArrayData === 'object') || (Array.isArray(objectArrayData))) {
+				// ensure value is an object, so convert arrays to object
+				let newObj = Array.isArray(objectArrayData) ? Utils.convertArrToObj(objectArrayData) : objectArrayData;
+	
+				// use an object to for loop through the keys and create new nodes for only the first level of keys as branches
+				// then put the value of the property to the newly generated object. This means empty objects or arrays will
+				// create nothing
+				for (let iPropName in newObj) {
+					let newNode: GNode;
+					if (paramData instanceof GNode) {
+						newNode = paramData;
+					} else if (newObj[iPropName] instanceof GNode) {
+						newNode = newObj[iPropName];
+					} else {
+						newNode = this.root.newNode();
+					}
+
+					/** @todo add an even that allows user to cancel write to node,
+					 *  or change values like in transactions. */
+	
+					// now if this isn't a GNode, call put to add the value of the property and let the new node handle what
+					// it needs to handle
+					if (!(paramData instanceof GNode) && !(newObj[iPropName] instanceof GNode)) {
+						await newNode.put(newObj[iPropName]);
+					}
+
+					// now that the new value for the node has been saved, create the branch to activate sorting, and have
+					// reference to the new node.
+					this.__data.branches[iPropName] = newNode.__data.nodeId;
+				}
+			} else {
+				let nonArrayOrObjectVal: boolean | null | number | string | undefined;
+				if (paramData === null || paramData === undefined) {
+					nonArrayOrObjectVal = undefined;
+				} else if (typeof paramData === 'string') {
+					nonArrayOrObjectVal = String(paramData);
+				} else if (typeof paramData === 'number') {
+					nonArrayOrObjectVal = Number(paramData);
+				} else if (typeof paramData === 'boolean') {
+					nonArrayOrObjectVal = Boolean(paramData);
+				} else {
+					nonArrayOrObjectVal = undefined;
+				}
+
+				/** @todo add an even that allows user to cancel write to node,
+				 *  or change values like in transactions. */
+	
+				this.__data.value = nonArrayOrObjectVal;
+			}
+	
+			return this;
+		} catch (e) {
+			throw e;
+		}
+	}
+
+	/**
+	 * Get a node reference to a GNode, at a given path.
+	 *
+	 *
+	 * @param {(Array<string>|string)} paramPath Path is relative to this GNode instance
+	 * @returns {Promise<GNode>} The GNode at given path. New Gnode are created if path does not exist.
+	 * @memberof GNode
+	 */
+	async ref(paramPath: Array<string> | string): Promise<GNode> {
+		try {
+			let incomingPathArray: Array<string> = Array.isArray(Array) ? new Array(String(paramPath)).concat() : String(paramPath).split('/');
+			let currGNode: GNode = this;
+
+			if (typeof paramPath === 'string') {
+				// string splicing adds a blank string to the first index at times
+				for (let i in incomingPathArray) {
+					if (!incomingPathArray[i]) {
+						incomingPathArray.splice(0, 1);
+					}
+				}
+			}
+
+			// go through the path array
+			if (incomingPathArray.length > 0) {
+				const [firstPathName, ...restOfPathsArr] = incomingPathArray;
+				let branchName = firstPathName;
+				let branchNodeId = currGNode.__data.branches ? currGNode.__data.branches[branchName] : undefined;
+				if (!branchNodeId) {
+					// if this has branches, it cannot have value
+					currGNode.__data.value = undefined;
+				}
+
+				let newGNode = this.root.newNode(branchNodeId);
+
+				// add the branch by referencing the branchNode id to the branchName
+				currGNode.__data.branches[branchName] = newGNode;
+
+				// now have the new node cretae its own branches according to the length of the path.
+				if (restOfPathsArr && restOfPathsArr.length > 0) {
+					currGNode = await newGNode.ref(restOfPathsArr);
+				} else {
+					currGNode = newGNode;
+				}
+			}
+
+			return currGNode;
+		} catch (e) {
+			throw (e);
+		}
+	}
+
+	/**
+	 * Get the data from any path starting at this reference.
+	 * calling getData('/') is the same as calling val()
+	 *
+	 * can use template literals as well, ie: getData(`{}`)
+	 *
+	 * @param {string} pathLiteal
+	 * @param {IGetDataOptions} [options]
+	 * @returns
+	 * @memberof GNode
+	 */
+	public async getData(pathLiteal: string, options?: IGetDataOptions) {
+		try {
+			let pathsArr;
+			let data;
+	
+			if (pathLiteal.trim().startsWith('{')) {
+				pathsArr = Utils.literalToPathsArr`${pathLiteal}`;
+			} else {
+				pathsArr = [[pathLiteal]];
+			}
+	
+			for (let iPath = 0; iPath < pathsArr.length; iPath++) {
+				let ref;
+				let path;
+	
+				// eslint-disable-next-line
+				pathsArr[iPath] = pathsArr[iPath] as Array<string>
+				path = pathsArr[iPath].join('/');
+				if (path.startsWith('/')) {
+					path = path.replace('/', '');
+				}
+	
+				ref = (path) ? await this.ref(path) : this;
+				data = await ref.val();
+			}
+	
+			return data;
+		} catch (e) {
+			throw e;
+		}
+	}
+
+	/**
+	 * Get the value of a node.data.value or node.data.branches[i] if there is no value for the node.
+	 * If the branches does not have a value defined, it will return
+	 *
+	 * Return value priority explained:
+	 *  1. If there is a value, return the value.
+	 *  2. Else, if there are branches, return value for branches.
+	 * 		- Branches without values will return gnode object entire data value.
+	 *  3. If there are no branches and no values, returns undefined/null.
+	 *
+	 * @returns {Promise<boolean|undefined|null|number|string|object>}
+	 * @memberof GNode
+	 */
+	public async val(): Promise<boolean | undefined | null | number | string | object> {
+		try {
+			if ((this.data.value === undefined || this.data.value === null) && (Object.keys(this.data.branches).length > 0)) {
+				let outObj = {};
+				for (let iPropName in this.data.branches) {
+					let branchNodeId = this.data.branches[iPropName];
+					let gNodeToGetValFrom = this.root.worldNet.gNodes[branchNodeId];
+					let value;
+
+					// only get values in the first level of the object... going deeper can lead to
+					// infinite loops from circular references.
+					// null is considered a type object
+					value = gNodeToGetValFrom.data.value;
+					if ((Object.keys(gNodeToGetValFrom.data.branches).length > 0) && ((value === undefined) || (value === null))) {
+						value = JSON.parse(JSON.stringify(gNodeToGetValFrom.data.branches));
+					}
+
+					outObj[iPropName] = value;
+				}
+
+				return outObj;
+			} else {
+				return this.data.value;
+			}
+		} catch (e) {
+			throw e;
+		}
+	}
+}

--- a/src/components/GNodeRoot.ts
+++ b/src/components/GNodeRoot.ts
@@ -1,0 +1,45 @@
+import { GNode } from "./GNode";
+
+interface IWorldNet {
+	jsonNodes : IJsonNode,
+	gNodes : undefined | object
+}
+
+interface IJsonNode {
+	branches ?: object | undefined,
+	value ?: boolean | null | number | string | undefined
+}
+
+export class GNodeRoot extends GNode {
+	private __worldNet : IWorldNet
+
+	public set worldNet (val : IWorldNet) {
+		// only null or undefined will reset the world net
+		this.worldNet = val;
+	}
+	public get worldNet () : IWorldNet {
+		if (!this.__worldNet) {
+			this.__worldNet = {
+				jsonNodes: {},
+				gNodes: {}
+			};
+		}
+
+		// Deref the object so it cannot be manipulated by reference.
+		return this.__worldNet;
+	}
+
+	public newNode (id ?: string) {
+		let worldNet = this.worldNet; // this initializes worldNet, read only
+		let newNode : GNode = (id) ? worldNet.gNodes[id] : undefined;
+
+		if (!newNode) {
+			newNode = new GNode({root: this});
+		}
+
+		this.__worldNet.gNodes[newNode.nodeId] = newNode;
+		this.__worldNet.jsonNodes[newNode.nodeId] = newNode.data;
+
+		return newNode;
+	}
+}

--- a/src/components/GUID_MANAGER.ts
+++ b/src/components/GUID_MANAGER.ts
@@ -1,0 +1,85 @@
+/**
+ * Fancy ID generator that creates 20-character string identifiers with the following properties:
+ *
+ * 1. They're based on timestamp so that they sort *after* any existing ids.
+ * 2. They contain 72-bits of random data after the timestamp so that IDs won't collide with other clients' IDs.
+ * 3. They sort *lexicographically* (so the timestamp is converted to characters that will sort properly).
+ * 4. They're monotonically increasing.  Even if you generate more than one in the same timestamp, the
+ *    latter ones will sort after the former ones.  We do this by using the previous random bits
+ *    but "incrementing" them by 1 (only in the case of a timestamp collision).
+ */
+// Modeled after base64 web-safe chars, but ordered by ASCII.
+const PUSH_CHARS = '-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz';
+
+// Timestamp of last push, used to prevent local collisions if you push twice in one ms.
+// let lastPushTime = 0;
+
+// We generate 72-bits of randomness which get turned into 12 characters and appended to the
+// timestamp to prevent collisions with other clients.  We store the last characters we
+// generated because in the event of a collision, we'll use those same characters except
+// "incremented" by one.
+// let lastRandChars = [];
+
+/**
+ * Manager that handles creating singletons for generating keys.
+ *
+ * @export
+ * @class GUID_MANAGER
+ */
+export class GUID_MANAGER {
+	private __lastPushTime : number
+	private __lastRandChars : Array<number>
+	private __PUSH_CHARS : string;
+	private __SINGLETONS : object;
+
+	constructor (id) {
+		if (!this.__SINGLETONS) {
+			this.__SINGLETONS = {};
+		}
+
+		if (this.__SINGLETONS.hasOwnProperty(id)) {
+			return this.__SINGLETONS[id];
+		} else {
+			this.__PUSH_CHARS = PUSH_CHARS;
+			this.__lastPushTime = 0;
+			this.__lastRandChars = [];
+
+			this.__SINGLETONS[id] = this;
+		}
+	}
+
+	public key() {
+		let now = new Date().getTime();
+		let duplicateTime = (now === this.__lastPushTime);
+		let i;
+		this.__lastPushTime = now;
+
+		let timeStampChars = new Array(8);
+		for (i = 7; i >= 0; i--) {
+			timeStampChars[i] = this.__PUSH_CHARS.charAt(now % 64);
+			// NOTE: Can't use << here because javascript will convert to int and lose the upper bits.
+			now = Math.floor(now / 64);
+		}
+		if (now !== 0) throw new Error('We should have converted the entire timestamp.');
+
+		let id = timeStampChars.join('');
+
+		if (!duplicateTime) {
+			for (i = 0; i < 12; i++) {
+				this.__lastRandChars[i] = Math.floor(Math.random() * 64);
+			}
+		} else {
+			// If the timestamp hasn't changed since last push, use the same random number, except incremented by 1.
+			for (i = 11; i >= 0 && this.__lastRandChars[i] === 63; i--) {
+				this.__lastRandChars[i] = 0;
+			}
+			this.__lastRandChars[i]++;
+		}
+		for (i = 0; i < 12; i++) {
+			id += this.__PUSH_CHARS.charAt(this.__lastRandChars[i]);
+		}
+		if (id.length != 20) throw new Error('Length should be 20.');
+
+		return id;
+	}
+}

--- a/src/components/GUID_NODES.ts
+++ b/src/components/GUID_NODES.ts
@@ -1,0 +1,20 @@
+import { GUID_MANAGER } from "./GUID_MANAGER";
+
+/**
+ * Singleton used to generate uids for nodes.
+ *
+ * @export
+ * @class GUID_NODES
+ */
+export class GUID_NODES {
+	private static __manager : GUID_MANAGER;
+
+	private static get __MANAGER () : GUID_MANAGER {
+		if (!GUID_NODES.__manager) GUID_NODES.__manager = new GUID_MANAGER('GUID_NODES');
+		return GUID_NODES.__manager;
+	}
+
+	static key () {
+		return GUID_NODES.__MANAGER.key();
+	}
+}

--- a/src/components/RelaxedJSON.ts
+++ b/src/components/RelaxedJSON.ts
@@ -1,0 +1,647 @@
+/*
+  Copyright (c) 2013, Oleg Grenrus
+  All rights reserved.
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+      * Neither the name of the Oleg Grenrus nor the
+        names of its contributors may be used to endorse or promote products
+        derived from this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL OLEG GRENRUS BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+interface IToken {
+	type: string,
+	line: number,
+	value?: string
+}
+
+interface IRegExp {
+	type: string,
+	match: Array<any>
+}
+
+interface ITokenSpec {
+	re: RegExp,
+	f: Function
+}
+
+
+// opts.relaxed = opts.relaxed !== undefined ? opts.relaxed : true
+// opts.warnings = opts.warnings || opts.tolerant || false
+// opts.tolerant = opts.tolerant || false
+// opts.duplicate = opts.duplicate || false
+
+interface IState {
+	message: string,
+	tolerant: boolean,
+	warnings: Array<IWarning> | boolean,
+	reviver: Function,
+	relaxed: boolean,
+	duplicate: boolean,
+}
+
+interface IWarning {
+	message: string,
+	line: number
+}
+
+class MySyntaxError extends SyntaxError {
+	private __line: number;
+	private __warnings: Array<IWarning>
+	private __obj: any
+
+	public set line(paramVal: number) {
+		this.__line = paramVal;
+	}
+	public get line() {
+		return this.__line;
+	}
+
+	public get obj() {
+		return this.__obj;
+	}
+	public set obj(val) {
+		this.__obj = val;
+	}
+
+	public get warnings(): Array<IWarning> {
+		return this.__warnings;
+	}
+	public set warnings(val: Array<IWarning>) {
+		this.__warnings = val;
+	}
+}
+
+export class RelaxedJSON {
+	private __lexer: Function;
+	private __strictLexer: Function;
+
+	constructor() {
+		this.__lexer = this.__makeLexer(this.__makeTokenSpecs(true));
+		this.__strictLexer = this.__makeLexer(this.__makeTokenSpecs(false));
+	}
+
+	// slightly different from ES5 __some, without cast to boolean
+	// [x, y, z].__some(f):
+	// ES5:  !! ( f(x) || f(y) || f(z) || false)
+	// this:    ( f(x) || f(y) || f(z) || false)
+	private __some(array, f): any {
+		let acc = false
+		for (let i = 0; i < array.length; i++) {
+			acc = f(array[i], i, array)
+			if (acc) {
+				return acc
+			}
+		}
+		return acc
+	}
+
+	private __makeLexer(tokenSpecs) {
+		let that = this;
+		return function (contents) {
+			let tokens = []
+			let line = 1
+
+			function findToken() {
+				return that.__some(tokenSpecs, function (tokenSpec) {
+					let m = tokenSpec.re.exec(contents)
+					if (m) {
+						let raw = m[0]
+						contents = contents.slice(raw.length)
+						return {
+							raw: raw,
+							matched: tokenSpec.f(m, line)
+						}
+					} else {
+						return undefined
+					}
+				})
+			}
+
+			while (contents !== '') {
+				let matched = findToken()
+
+				if (!matched) {
+					let err = new MySyntaxError('Unexpected character: ' + contents[0] + '; input: ' + contents.substr(0, 100))
+					err.line = line
+					throw err
+				}
+
+				// add line to token
+				matched.matched.line = line
+
+				// count lines
+				line += matched.raw.replace(/[^\n]/g, '').length
+
+				tokens.push(matched.matched)
+			}
+
+			return tokens
+		}
+	}
+
+	private __fStringSingle(m) {
+		// String in single quotes
+		let content = m[1].replace(/([^'\\]|\\['bnrtf\\]|\\u[0-9a-fA-F]{4})/g, function (mm) {
+			if (mm === '"') {
+				return '\\"'
+			} else if (mm === '\\\'') {
+				return '\''
+			} else {
+				return mm
+			}
+		})
+
+		return {
+			type: 'string',
+			match: '"' + content + '"',
+			value: JSON.parse('"' + content + '"') // abusing real JSON.parse to unquote string
+		}
+	}
+
+	private __fStringDouble(m) {
+		return {
+			type: 'string',
+			match: m[0],
+			value: JSON.parse(m[0])
+		}
+	}
+
+	private __fIdentifier(m) {
+		// identifiers are transformed into strings
+		return {
+			type: 'string',
+			value: m[0],
+			match: '"' + m[0].replace(/./g, function (c) {
+				return c === '\\' ? '\\\\' : c
+			}) + '"'
+		}
+	}
+
+	private __fComment(m) {
+		// comments are whitespace, leave only linefeeds
+		return {
+			type: ' ',
+			match: m[0].replace(/./g, function (c) {
+				return (/\s/).test(c) ? c : ' '
+			})
+		}
+	}
+
+	private __fNumber(m) {
+		return {
+			type: 'number',
+			match: m[0],
+			value: parseFloat(m[0])
+		}
+	}
+
+	private __fKeyword(m) {
+		var value
+		switch (m[1]) {
+			case 'null': value = null; break
+			case 'true': value = true; break
+			case 'false': value = false; break
+			// no default
+		}
+		return {
+			type: 'atom',
+			match: m[0],
+			value: value
+		}
+	}
+
+	private __makeTokenSpecs(relaxed): Array<ITokenSpec> {
+		function f(type): Function {
+			return function (m): IRegExp {
+				return { type: type, match: m[0] }
+			}
+		}
+
+		/* eslint-disable no-useless-escape */
+		var ret = [
+			{ re: /^\s+/, f: f(' ') },
+			{ re: /^\{/, f: f('{') },
+			{ re: /^\}/, f: f('}') },
+			{ re: /^\[/, f: f('[') },
+			{ re: /^\]/, f: f(']') },
+			{ re: /^,/, f: f(',') },
+			{ re: /^:/, f: f(':') },
+			{ re: /^(true|false|null)/, f: this.__fKeyword },
+			{ re: /^\-?\d+(\.\d+)?([eE][+-]?\d+)?/, f: this.__fNumber },
+			{ re: /^"([^"\\]|\\["bnrtf\\\/]|\\u[0-9a-fA-F]{4})*"/, f: this.__fStringDouble }
+		];
+
+		// additional stuff
+		if (relaxed) {
+			ret = ret.concat([
+				{ re: /^'(([^'\\]|\\['bnrtf\\\/]|\\u[0-9a-fA-F]{4})*)'/, f: this.__fStringSingle },
+				{ re: /^\/\/.*?(?:\r\n|\r|\n)/, f: this.__fComment },
+				{ re: /^\/\*[\s\S]*?\*\//, f: this.__fComment },
+				{ re: /^[$a-zA-Z0-9_\-+\.\*\?!\|&%\^\/#\\]+/, f: this.__fIdentifier }
+			]);
+		}
+	  /* eslint-enable no-useless-escape */ret
+
+		return ret;
+	}
+
+	private __previousNWSToken(tokens, index) {
+		for (; index >= 0; index--) {
+			if (tokens[index].type !== ' ') {
+				return index
+			}
+		}
+		return undefined
+	}
+
+	private __stripTrailingComma(tokens) {
+		var res = []
+		var that = this;
+
+		tokens.forEach(function (token, index) {
+			if (token.type === ']' || token.type === '}') {
+				// go backwards as long as there is whitespace, until first comma
+				var commaI = that.__previousNWSToken(res, index - 1);
+
+				if (commaI && res[commaI].type === ',') {
+					var preCommaI = that.__previousNWSToken(res, commaI - 1);
+					if (preCommaI && res[preCommaI].type !== '[' && res[preCommaI].type !== '{') {
+						res[commaI] = {
+							type: ' ',
+							match: ' ',
+							line: tokens[commaI].line
+						}
+					}
+				}
+			}
+
+			res.push(token)
+		})
+
+		return res
+	}
+
+	public transform(text) {
+		// Tokenize contents
+		var tokens = this.__lexer(text)
+
+		// remove trailing commas
+		tokens = this.__stripTrailingComma(tokens)
+
+		// concat stuff
+		return tokens.reduce(function (str, token) {
+			return str + token.match
+		}, '')
+	}
+
+	private __popToken(tokens, state): IToken {
+		var token = tokens[state.pos];
+		state.pos += 1;
+
+		if (!token) {
+			var line = tokens.length !== 0 ? tokens[tokens.length - 1].line : 1;
+			return { type: 'eof', line: line };
+		}
+
+		return token
+	}
+
+	private __strToken(token) {
+		switch (token.type) {
+			case 'atom':
+			case 'string':
+			case 'number':
+				return token.type + ' ' + token.match
+			case 'eof':
+				return 'end-of-file'
+			default:
+				return '' + token.type + ''
+		}
+	}
+
+	private __skipColon(tokens, state) {
+		var colon = this.__popToken(tokens, state)
+		if (colon.type !== ':') {
+			var message = 'Unexpected token: ' + this.__strToken(colon) + ', expected \':\''
+			if (state.tolerant) {
+				state.warnings.push({
+					message: message,
+					line: colon.line
+				})
+
+				state.pos -= 1
+			} else {
+				var err = new MySyntaxError(message)
+				err.line = colon.line
+				throw err
+			}
+		}
+	}
+
+	private __skipPunctuation(tokens, state: IState, valid?: Array<string>): IToken {
+		let punctuation: Array<string> = [',', ':', ']', '}'];
+		let token: IToken = this.__popToken(tokens, state);
+		while (true) { // eslint-disable-line no-constant-condition
+			if ((!!valid === true) && (valid.indexOf(token.type) !== -1)) {
+				return token;
+			} else if (token.type === 'eof') {
+				return token;
+			} else if (punctuation.indexOf(token.type) !== -1) {
+				let message: string = 'Unexpected token: ' + this.__strToken(token) + ', expected \'[\', \'{\', number, string or atom'
+				if (state.tolerant) {
+					state.warnings = state.warnings as Array<IWarning>;
+					state.warnings.push({
+						message: message,
+						line: token.line
+					});
+					token = this.__popToken(tokens, state);
+				} else {
+					let err: MySyntaxError = new MySyntaxError(message);
+					err.line = token.line;
+					throw err;
+				}
+			} else {
+				return token;
+			}
+		}
+	}
+
+	private __raiseError(state: IState, token, message) {
+		if (state.tolerant) {
+			state.warnings = state.warnings as Array<IWarning>;
+			state.warnings.push({
+				message: message,
+				line: token.line
+			})
+		} else {
+			var err = new MySyntaxError(message)
+			err.line = token.line
+			throw err
+		}
+	}
+
+	private __raiseUnexpected(state: IState, token, expected) {
+		this.__raiseError(state, token, 'Unexpected token: ' + this.__strToken(token) + ', expected ' + expected)
+	}
+
+	private __checkDuplicates(state: IState, obj, token: IToken) {
+		let key: String = token.value;
+
+		if (state.duplicate && Object.prototype.hasOwnProperty.call(obj, key)) {
+			this.__raiseError(state, token, 'Duplicate key: ' + key);
+		}
+	}
+
+	private __appendPair(state: IState, obj, key, value) {
+		value = state.reviver ? state.reviver(key, value) : value
+		if (value !== undefined) {
+			obj[key] = value
+		}
+	}
+
+	private __parsePair(tokens, state, obj) {
+		let token: IToken = this.__skipPunctuation(tokens, state, [':']);
+		let key;
+		let value;
+
+		if (token.type !== 'string') {
+			this.__raiseUnexpected(state, token, 'string')
+			switch (token.type) {
+				case ':':
+					token = {
+						type: 'string',
+						value: 'null',
+						line: token.line
+					}
+
+					state.pos -= 1
+					break
+
+				case 'number':
+				case 'atom':
+					token = {
+						type: 'string',
+						value: '' + token.value,
+						line: token.line
+					}
+					break
+
+				case '[':
+				case '{':
+					state.pos -= 1
+					value = this.__parseAny(tokens, state) // eslint-disable-line no-use-before-define
+					this.__appendPair(state, obj, 'null', value)
+					return
+				// no default
+			}
+		}
+
+		this.__checkDuplicates(state, obj, token)
+		key = token.value
+		this.__skipColon(tokens, state)
+		value = this.__parseAny(tokens, state) // eslint-disable-line no-use-before-define
+
+		this.__appendPair(state, obj, key, value)
+	}
+
+	private __parseElement(tokens, state, arr: Array<any>) {
+		let key: number = arr.length;
+		let value: any = this.__parseAny(tokens, state); // eslint-disable-line no-use-before-define
+		arr[key] = state.reviver ? state.reviver('' + key, value) : value;
+	}
+
+	private __parseObject(tokens, state) {
+		return this.__parseMany(tokens, state, {}, { // eslint-disable-line no-use-before-define
+			skip: [':', '}'],
+			elementParser: this.__parsePair,
+			elementName: 'string',
+			endSymbol: '}'
+		})
+	}
+
+	private __parseArray(tokens, state) {
+		return this.__parseMany(tokens, state, [], { // eslint-disable-line no-use-before-define
+			skip: [']'],
+			elementParser: this.__parseElement,
+			elementName: 'json object',
+			endSymbol: ']'
+		})
+	}
+
+	private __parseMany(tokens, state, obj, opts) {
+		var token: IToken = this.__skipPunctuation(tokens, state, opts.skip)
+
+		if (token.type === 'eof') {
+			this.__raiseUnexpected(state, token, '\'' + opts.endSymbol + '\' or ' + opts.elementName)
+
+			token = {
+				type: opts.endSymbol,
+				line: token.line
+			}
+		}
+
+		switch (token.type) {
+			case opts.endSymbol:
+				return obj;
+
+			default:
+				state.pos -= 1 // push the token back
+				opts.elementParser(tokens, state, obj)
+				break
+		}
+
+		// Rest
+		while (true) { // eslint-disable-line no-constant-condition
+			token = this.__popToken(tokens, state)
+
+			if (token.type !== opts.endSymbol && token.type !== ',') {
+				this.__raiseUnexpected(state, token, '\',\' or \'' + opts.endSymbol + '\'')
+
+				token = {
+					type: token.type === 'eof' ? opts.endSymbol : ',',
+					line: token.line
+				}
+
+				state.pos -= 1
+			}
+
+			switch (token.type) {
+				case opts.endSymbol:
+					return obj
+
+				case ',':
+					opts.elementParser(tokens, state, obj)
+					break
+				// no default
+			}
+		}
+	}
+
+	private __endChecks(tokens, state, ret) {
+		if (state.pos < tokens.length) {
+			this.__raiseError(state, tokens[state.pos],
+				'Unexpected token: ' + this.__strToken(tokens[state.pos]) + ', expected end-of-input')
+		}
+
+		// Throw error at the end
+		if (state.tolerant && state.warnings.length !== 0) {
+			let message = state.warnings.length === 1 ? state.warnings[0].message : state.warnings.length + ' parse warnings';
+			let err = new MySyntaxError(message);
+			err.line = state.warnings[0].line;
+			err.warnings = state.warnings;
+			err.obj = ret;
+			throw err;
+		}
+	}
+
+	private __parseAny(tokens, state, end?: boolean) {
+		let token = this.__skipPunctuation(tokens, state);
+		let ret;
+
+		if (token.type === 'eof') {
+			this.__raiseUnexpected(state, token, 'json object')
+		}
+
+		switch (token.type) {
+			case '{':
+				ret = this.__parseObject(tokens, state)
+				break;
+			case '[':
+				ret = this.__parseArray(tokens, state)
+				break;
+			case 'string':
+			case 'number':
+			case 'atom':
+				ret = token.value
+				break;
+			// no default
+		}
+
+		if (end) {
+			ret = state.reviver ? state.reviver('', ret) : ret;
+			this.__endChecks(tokens, state, ret)
+		}
+
+		return ret
+	}
+
+	public parse(text, opts?: IState) {
+		if (typeof opts === 'function' || opts === undefined) {
+			return JSON.parse(this.transform(text), opts as any)
+		} else if (new Object(opts) !== opts) { // eslint-disable-line no-new-object
+			throw new TypeError('opts/reviver should be undefined, a function or an object')
+		}
+
+		opts.relaxed = opts.relaxed !== undefined ? opts.relaxed : true
+		opts.warnings = opts.warnings || opts.tolerant || false
+		opts.tolerant = opts.tolerant || false
+		opts.duplicate = opts.duplicate || false
+
+		if (!opts.warnings && !opts.relaxed) {
+			return JSON.parse(text, opts.reviver as any)
+		}
+
+		var tokens = opts.relaxed ? this.__lexer(text) : this.__strictLexer(text)
+
+		if (opts.relaxed) {
+			// Strip commas
+			tokens = this.__stripTrailingComma(tokens)
+		}
+
+		if (opts.warnings) {
+			// Strip whitespace
+			tokens = tokens.filter(function (token) {
+				return token.type !== ' '
+			})
+
+			var state = { pos: 0, reviver: opts.reviver, tolerant: opts.tolerant, duplicate: opts.duplicate, warnings: [] }
+			return this.__parseAny(tokens, state, true)
+		} else {
+			var newtext = tokens.reduce(function (str, token) {
+				return str + token.match
+			}, '')
+
+			return JSON.parse(newtext, opts.reviver as any)
+		}
+	}
+
+	private __stringifyPair(obj, key) {
+		return JSON.stringify(key) + ':' + this.stringify(obj[key]) // eslint-disable-line no-use-before-define
+	}
+
+	public stringify(obj) {
+		switch (typeof obj) {
+			case 'string':
+			case 'number':
+			case 'boolean':
+				return JSON.stringify(obj);
+			// no default
+		}
+		if (Array.isArray(obj)) {
+			return '[' + obj.map(this.stringify).join(',') + ']';
+		}
+		if (new Object(obj) === obj) { // eslint-disable-line no-new-object
+			var keys = Object.keys(obj);
+			keys.sort();
+			return '{' + keys.map(this.__stringifyPair.bind(null, obj)) + '}';
+		}
+		return 'null';
+	}
+}
+
+export default RelaxedJSON;

--- a/src/components/Utils.ts
+++ b/src/components/Utils.ts
@@ -1,0 +1,137 @@
+import { RelaxedJSON } from "./RelaxedJSON";
+
+export interface ISortData {
+	key,
+	index,
+	value
+}
+
+export class Utils {
+	static __JSON_PARSER: RelaxedJSON;
+
+	static get JSON_PARSER() {
+		if (!Utils.__JSON_PARSER) {
+			Utils.__JSON_PARSER = new RelaxedJSON();
+		}
+
+		return Utils.__JSON_PARSER;
+	}
+
+	static convertArrToObj(paramArr: Array<any>, paramOutObj?: object) {
+		let o = paramOutObj || {};
+		let cur;
+		let keys;
+
+		paramArr.forEach(function (a) {
+			keys = a.slice(0, a.length - 2);
+			cur = o;
+
+			keys.forEach(function (k) {
+				if (cur[k] == null) {
+					cur[k] = {};
+				}
+				cur = cur[k];
+			});
+
+			cur[a[a.length - 2]] = a[a.length - 1]
+		});
+
+		return o;
+	}
+
+	public static convertStrToObj(str) {
+		try {
+			if (typeof str === 'string') {
+				return Utils.JSON_PARSER.parse(str);
+			}
+		} catch (e) {
+			throw (e);
+		}
+	}
+
+	private static __handleCreatePathsIter(o, p, result) {
+		let keys = Object.keys(o);
+		if (keys.length) {
+			return keys.forEach(function (k) {
+				Utils.__handleCreatePathsIter(o[k], p.concat(k), result);
+			});
+		}
+		result.push(p);
+	}
+
+	public static handleCreatePaths(object): Array<any> {
+		try {
+			let result = [];
+
+			Utils.__handleCreatePathsIter(object, [], result);
+
+			return result;
+		} catch (e) {
+			throw (e);
+		}
+	}
+
+	public static literalToPathsArr(strings, ...listOfExps): Array<Array<string>> {
+		try {
+			let rawString = '';
+
+			for (let iStr = 0; iStr < strings.length; iStr++) {
+				rawString = rawString + strings[iStr];
+
+				// now add the variables passed in
+				if (iStr < listOfExps.length) {
+					rawString = rawString + listOfExps[iStr];
+				}
+			}
+
+			// Strip insignificant whitespace
+			// Note that this could do a lot more, such as reorder fields etc.
+			// normalize
+			rawString = rawString.replace(/[\s,]+/g, ' ').trim()
+
+			let pathsArr = Utils.handleCreatePaths(Utils.convertStrToObj(rawString)) as Array<Array<string>>;
+
+			return pathsArr;
+		} catch (e) {
+			throw (e);
+		}
+	}
+
+	// basic implementation (pivot is the first element of the array)
+	public static quicksortBasic(array: Array<any>, sortCb?: Function) {
+		try {
+			let length;
+			length = array.length;
+	
+			if (length < 2) {
+				return array;
+			} else {
+				let isGreater;
+				let pivot = array.splice(0, 1)[0];
+				let lesser = [];
+				let greater = [];
+		
+				for (let i in array) {
+					if (typeof sortCb === 'function') {
+						isGreater = sortCb(pivot, array[i]);
+					} else {
+						isGreater = (array[i] > pivot);
+					}
+		
+					// if its greate push to greater.
+					if (isGreater) {
+						greater.push(array[i]);
+					} else {
+						lesser.push(array[i]);
+					}
+				}
+
+				let newArray = Utils.quicksortBasic(lesser, sortCb).concat(pivot, Utils.quicksortBasic(greater, sortCb));
+				return newArray;
+			}
+	
+		} catch (e) {
+			throw e;
+		}
+	}
+}

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,0 +1,45 @@
+{
+  "name": "grafiki",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/events": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
+    },
+    "@types/node": {
+      "version": "10.12.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.9.tgz",
+      "integrity": "sha512-eajkMXG812/w3w4a1OcBlaTwsFPO5F7fJ/amy+tieQxEMWBlbV1JGSjkFM+zkHNf81Cad+dfIRA+IBkvmvdAeA=="
+    },
+    "@types/ws": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.1.tgz",
+      "integrity": "sha512-EzH8k1gyZ4xih/MaZTXwT2xOkPiIMSrhQ9b8wrlX88L0T02eYsddatQlwVFlEPyEqV0ChpdpNnE51QPH6NVT4Q==",
+      "requires": {
+        "@types/events": "1.2.0",
+        "@types/node": "10.12.9"
+      }
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
+    "typescript": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+    },
+    "ws": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
+      "integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
+      "requires": {
+        "async-limiter": "1.0.0"
+      }
+    }
+  }
+}

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "grafiki",
+  "version": "0.0.1",
+  "description": "Graf similar to GunDB but in typescript.",
+  "main": "Grafiki.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Jajav33",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@types/ws": "^6.0.1",
+    "typescript": "^3.1.6",
+    "ws": "^6.1.2"
+  }
+}

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,0 +1,120 @@
+import { Grafiki } from "../src/Grafiki";
+
+class MyTest {
+	constructor() {
+	}
+
+	async runTests() {
+		try {
+			// let result = await this.testInitGrafiki();
+			// let result = await this.getInNode();
+			// let result = await this.putInNode();
+			let result = await this.getDataFromNode();
+
+			// let useTemplateLiteral = true;
+			// let result = await this.getDataFromNode(useTemplateLiteral);
+
+			return result;
+		} catch (e) {
+			console.group('error')
+			console.error(e);
+			for (let i in e) {
+				console.log(e[i]);
+			}
+			console.groupEnd()
+		}
+	}
+
+	async testInitGrafiki() {
+		return new Grafiki();
+	}
+
+	async getDataFromNode(useTemplateLiteral?: boolean) {
+		try {
+
+			let g = new Grafiki();
+			let doggyRef = await g.ref('/dogs/doggie');
+			let jajav33Ref = await g.ref('/people/jajav33');
+	
+			await doggyRef.put({
+				name: 'doggie',
+				isAwesome: true,
+				age: 18,
+				owners: {
+					'jajav33': jajav33Ref
+				}
+			});
+	
+			await jajav33Ref.put({
+				name: 'jajav33',
+				isAwesome: true,
+				age: 31,
+				pets: {
+					'doggie': doggyRef
+				},
+				'3': 3,
+				'1': 7,
+				'7': 3,
+				'0': 1,
+			});
+	
+			// let pathQuery = '/pets';
+			let pathQuery = '/';
+			if (useTemplateLiteral) {
+				pathQuery = `{
+					pets: {}
+				}`
+			}
+	
+			let result = await jajav33Ref.getData(pathQuery);
+	
+			return result;
+		} catch (e) {
+			throw e;
+		}
+	}
+
+	async getInNode() {
+		let g = new Grafiki();
+		let newRef = await g.ref('/new/path');
+
+		return newRef;
+	}
+
+	async putInNode() {
+		let g = new Grafiki();
+		let doggyRef = await g.ref('/dogs/doggie');
+		let jajav33Ref = await g.ref('/people/jajav33');
+
+		await doggyRef.put({
+			name: 'doggie',
+			isAwesome: true,
+			age: 18,
+			owners: {
+				'jajav33': jajav33Ref
+			}
+		});
+
+		await jajav33Ref.put({
+			name: 'jajav33',
+			isAwesome: true,
+			age: 31,
+			pets: {
+				'doggie': doggyRef
+			}
+		});
+
+		return [doggyRef, jajav33Ref];
+	}
+
+	async pushToNode() {
+		let g = new Grafiki();
+		let newRef = await g.ref('/new/path');
+
+		return newRef;
+	}
+}
+
+let test = new MyTest();
+
+test.runTests();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"compilerOptions": {
+		"target": "es5",
+		"lib": [ "es2015" ]
+	}
+}


### PR DESCRIPTION
Had done a few changes in my local version before deciding to move to to github so my bad for the one commit push.

#feature: `put` allows you to add data into a json as a node in a graph, array are converted to objects, and objects are added as branches not values.
#feature: `push` allows you to add data as a list. In Grafiki terms, push is added as a branch.
#feature: `getData` gets data in relative path to the node. Can use */path/to* or template literal *{path: { to: {} }*
#feature: `val` gets the value of just the node itself two levels deep. Priority for determining value is first check the nodes data.value. If undefined, then check data.branches[].val(). Lastly, if branches' vals are more branches, will return the next nodes branches names with the next level nodeId.
#feature: `ref` gets the reference to a node in the graph based on a relative path to the node. This acts like going down the JSON tree. If the path does not exists yet, it will create a node for that path.